### PR TITLE
matrigram: Show room history on focus change

### DIFF
--- a/matrigram/bot.py
+++ b/matrigram/bot.py
@@ -269,7 +269,11 @@ class MatrigramBot(telepot.Bot):
 
         self.sendChatAction(chat_id, 'typing')
         client = self._get_client(chat_id)
+
         client.set_focus_room(room_name)
+        self.sendMessage(chat_id, '{} Room history:'.format(room_name))
+        client.backfill_previous_messages()
+
         self.answerCallbackQuery(query_id, 'Done!')
         self.sendMessage(chat_id, 'You are now participating in {}'.format(room_name))
 

--- a/matrigram/client.py
+++ b/matrigram/client.py
@@ -184,6 +184,10 @@ class MatrigramClient(object):
             logger.error('error creating room')
             return None, None
 
+    def backfill_previous_messages(self, limit=10):
+        room_obj = self.get_room_obj(self.focus_room_id)
+        room_obj.backfill_previous_messages(limit=limit)
+
     def get_rooms_aliases(self):
         # returns a dict with id: room obj
         rooms = self._get_rooms_updated()


### PR DESCRIPTION
NOTE: This patch depends on pull request from matrix-python-sdk.
https://github.com/matrix-org/matrix-python-sdk/pull/81

```
When changing room focus, show the last N messages in the new room.

Issue: #2
Signed-off-by: Gal Pressman <galpressman@gmail.com>
```