### PR TITLE
matrigram: Modules naming refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,6 @@ install:
   - sh ./tests/init_config.sh
 # command to run tests
 script:
-  - flake8 --max-line-length=100 --ignore=F812 matrigram
-  - pylint --disable=redefined-builtin,ungrouped-imports,too-many-public-methods,fixme,missing-docstring,invalid-name,protected-access matrigram
+  - flake8 --max-line-length=100 --ignore=F812 matrigram matrigram_main.py
+  - pylint --disable=redefined-builtin,ungrouped-imports,too-many-public-methods,fixme,missing-docstring,invalid-name,protected-access matrigram matrigram_main.py
   - py.test

--- a/docs/code.rst
+++ b/docs/code.rst
@@ -6,16 +6,16 @@ Helper
 .. automodule:: matrigram.helper
    :members:
 
-Main
-^^^^
-.. automodule:: matrigram.matrigram_main
-.. autoclass:: Matrigram
+Bot
+^^^
+.. automodule:: matrigram.bot
+.. autoclass:: MatrigramBot
    :members:
    :undoc-members:
 
-Matrix Client
-^^^^^^^^^^^^^
-.. automodule:: matrigram.mc
-.. autoclass:: MC
+Client
+^^^^^^
+.. automodule:: matrigram.client
+.. autoclass:: MatrixClient
    :members:
    :undoc-members:

--- a/matrigram.py
+++ b/matrigram.py
@@ -1,4 +1,0 @@
-from matrigram import matrigram_main
-
-if __name__ == '__main__':
-    matrigram_main.main()

--- a/matrigram/client.py
+++ b/matrigram/client.py
@@ -13,7 +13,7 @@ from .helper import download_file
 from .helper import pprint_json
 
 
-class MC(object):
+class MatrigramClient(object):
     def __init__(self, server, tb, username):
         self.client = MatrixClient(server)
         self.tb = tb

--- a/matrigram_main.py
+++ b/matrigram_main.py
@@ -1,0 +1,35 @@
+import argparse
+import logging
+import os
+import tempfile
+
+from matrigram import helper
+from matrigram.bot import MatrigramBot
+
+
+def main():
+    logging.basicConfig(level=logging.DEBUG, format='%(asctime)s %(levelname)s'
+                        '%(module)s@%(funcName)s +%(lineno)d: %(message)s',
+                        datefmt='%H:%M:%S')
+    logging.getLogger('requests').setLevel(logging.WARNING)
+    logging.getLogger('urllib3').setLevel(logging.WARNING)
+
+    parser = argparse.ArgumentParser(description=helper.HELP_MSG)
+    parser.add_argument('--config', default='config.json', help='path to config file')
+    args = parser.parse_args()
+
+    config = helper.get_config(args.config)
+    media_dir = os.path.join(tempfile.gettempdir(), "matrigram")
+    if not os.path.exists(media_dir):
+        logging.debug('creating dir %s', media_dir)
+        os.mkdir(media_dir)
+
+    config['media_dir'] = media_dir
+    token = config['telegram_token']
+
+    mg = MatrigramBot(token, config=config)
+    mg.message_loop(run_forever='-I- matrigram running...')
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/matrigram_test.py
+++ b/tests/matrigram_test.py
@@ -1,14 +1,15 @@
-import matrigram.matrigram_main
-import multiprocessing
+import subprocess
+import shlex
+import time
 
 
 class TestMatrigram(object):
     def test_one(self):
-        p = multiprocessing.Process(target=matrigram.matrigram_main.main)
-        p.start()
+        cmd = 'python matrigram_main.py'
+        p = subprocess.Popen(shlex.split(cmd))
 
-        p.join(5)
+        time.sleep(5)
 
-        assert p.is_alive(), "matrigram did not boot"
+        assert not p.poll(), "matrigram did not boot"
         p.terminate()
-        p.join()
+        p.wait()


### PR DESCRIPTION
Changed the following:
- matrigram_main.py -> bot.py.
- mc.py -> client.py.
- matrigram.py -> matrigram_main.py.

And the classes changed accordingly to MatrigramBot and MatrigramClient.
This makes more sense to me, especially when we move the main() function
to the outer matrigram_main.py file.

Signed-off-by: Gal Pressman <galpressman@gmail.com>