### PR TITLE
matrigram: Move config file to home dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ $ pip install -r requirements.txt
 ```
 
 ###Usage
-First fill `config.json` with your details.
+First fill `~/.matrigramconfig` with your details (similar to `config.json.example`).
+If the config file doesn't exist, matrigram will create one for you to fill.
 
 Run using `matrigram_main.py`, which will enter an infinite listening loop:
 ```python

--- a/config.json.example
+++ b/config.json.example
@@ -1,4 +1,4 @@
 {
-  "telegram_token": "my_telegram_token_here",
-  "server": "http://localhost:8008"
+  "telegram_token": "tg_token",
+  "server": "http://matrix.org"
 }

--- a/matrigram/helper.py
+++ b/matrigram/helper.py
@@ -1,8 +1,11 @@
 import json
 import os
+import shutil
+
 import requests
 
 HELP_MSG = 'matrigram: A bridge between matrix and telegram'
+CONFIG_PATH = os.path.join(os.path.expanduser('~'), '.matrigramconfig')
 
 
 def pprint_json(to_print):
@@ -64,3 +67,25 @@ def chunks(l, n):
     """
     for i in range(0, len(l), n):
         yield l[i:i + n]
+
+
+def init_config():
+    """Init ~/.matrigramconfig.
+
+    """
+    shutil.copyfile('config.json.example', CONFIG_PATH)
+
+
+def token_changed(config):
+    """Check if telegram token is provided.
+
+    Args:
+        config (dict): Loaded config file.
+
+    Returns:
+        bool: True if the token has changed, else False.
+    """
+    token = config['telegram_token']
+    if token == 'tg_token':
+        return False
+    return True

--- a/matrigram_main.py
+++ b/matrigram_main.py
@@ -1,4 +1,3 @@
-import argparse
 import logging
 import logging.handlers
 import os
@@ -21,14 +20,12 @@ def main():
     logger.addHandler(sh)
     logger.addHandler(fh)
 
-    parser = argparse.ArgumentParser(description=helper.HELP_MSG)
-    parser.add_argument('--config', default='config.json', help='path to config file')
-    args = parser.parse_args()
-
-    if not os.path.isfile(args.config):
-        logging.error('config file not found, please use --config flag or create config.json file')
+    if not os.path.isfile(helper.CONFIG_PATH):
+        logger.error('Please fill the config file at %s', helper.CONFIG_PATH)
+        helper.init_config()
         return
-    config = helper.get_config(args.config)
+
+    config = helper.get_config(helper.CONFIG_PATH)
     media_dir = os.path.join(tempfile.gettempdir(), "matrigram")
     if not os.path.exists(media_dir):
         logging.debug('creating dir %s', media_dir)
@@ -36,6 +33,9 @@ def main():
 
     config['media_dir'] = media_dir
     token = config['telegram_token']
+    if not helper.token_changed(config):
+        logger.error('Please enter you tg token in %s', helper.CONFIG_PATH)
+        return
 
     mg = MatrigramBot(token, config=config)
     mg.message_loop(run_forever='-I- matrigram running...')

--- a/tests/init_config.sh
+++ b/tests/init_config.sh
@@ -4,8 +4,8 @@
 set -e
 set -x
 
-CONFIG_FILE="config.json"
+CONFIG_FILE="$HOME/.matrigramconfig"
 
 cp -f config.json.example $CONFIG_FILE
 set +x
-sed -i -- "s/my_telegram_token_here/""${TG_TOKEN}""/g" $CONFIG_FILE
+sed -i -- "s/tg_token/""${TG_TOKEN}""/g" $CONFIG_FILE


### PR DESCRIPTION
Use ~/.matrigramconfig as our config file.
If the file doesn't exist (first time running matrigram), we will create an example
which should be filled by the user.

Signed-off-by: Gal Pressman <galpressman@gmail.com>